### PR TITLE
Fixing /home/dse directory creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie-backports
 
 # Add DSE group and user
 RUN groupadd -r dse --gid=999 \
-    && useradd -r -g dse --uid=999 dse
+    && useradd -m -d /home/dse -r -g dse --uid=999 dse
 
 # gosu for easy step down from root
 ENV GOSU_VERSION 1.7


### PR DESCRIPTION
the useradd command didn't create the user's home directory, the PR changes the command to create the /home/dse directory. 
When running DSE as a search node, the log threw errors that it couldn't write to /home/dse/tomcat, this should resolve it.